### PR TITLE
Update game_manager.js for bugfix

### DIFF
--- a/js/game_manager.js
+++ b/js/game_manager.js
@@ -252,7 +252,7 @@ GameManager.prototype.tileMatchesAvailable = function () {
             tile = this.grid.cellContent({ x: x, y: y, z: z, w: w, v: v });
 
             if (tile) {
-              for (var direction = 0; direction < 8; direction++) {
+              for (var direction = 0; direction < 10; direction++) {
                 var vector = self.getVector(direction);
                 var cell   = { x: x + vector.x, y: y + vector.y,
                                z: z + vector.z, w: w + vector.w,


### PR DESCRIPTION
Traverse full direction set to fix bug (tileMatchesAvailable returns false if q/e move is all that remains)
<img width="1163" alt="Screen Shot 2019-05-20 at 10 42 13 PM" src="https://user-images.githubusercontent.com/8233914/58071160-8924c800-7b50-11e9-9c77-61b8858a6ccb.png">
